### PR TITLE
Extend support of json arrays.

### DIFF
--- a/JsonFile.js
+++ b/JsonFile.js
@@ -129,6 +129,55 @@ function isPrimitive(type) {
     return ["boolean", "number", "integer", "string"].indexOf(type) > -1;
 }
 
+/**
+ * Gets type of array of provided schema.
+ *
+ * TODO: Add support for "anyOf" and "oneOf" type definitions.
+ */
+function getArrayTypeFromSchema(schema) {
+    if (schema.type !== "array") {
+        return null;
+    }
+
+    var allowedTypes = ["string", "integer", "number", "boolean", "object"];
+
+    if (schema.items.type && allowedTypes.indexOf(schema.items.type) > -1) {
+        return schema.items.type;
+    }
+
+    // Default type is string for compatibility reasons.
+    return 'string';
+}
+
+/**
+ * Converts each element of one-dimensional array to a primitive type.
+ */
+function convertArrayElementsToType(array, type) {
+    if (!ilib.isArray(array)){
+        return array;
+    }
+
+    return array.map(function (item) {
+        return convertValueToType(item, type);
+    });
+}
+
+/**
+ * Converts value to a primitive type.
+ */
+function convertValueToType(value, type) {
+    switch (type) {
+        case "boolean":
+            return value === "true";
+        case "number":
+            return Number.parseFloat(value);
+        case "integer":
+            return Number.parseInt(value);
+        default:
+            return value;
+    }
+}
+
 var pluralCategories = {
     "zero": true,
     "one": true,
@@ -282,20 +331,7 @@ JsonFile.prototype.parseObj = function(json, root, schema, ref, name, localizabl
                             }
                         }
                         if (translatedText) {
-	                        switch (type) {
-	                        case "boolean":
-	                            returnValue = (translatedText === "true");
-	                            break;
-	                        case "number":
-	                            returnValue = Number.parseFloat(translatedText);
-	                            break;
-	                        case "integer":
-	                            returnValue = Number.parseInt(translatedText);
-	                            break;
-	                        default:
-	                            returnValue = translatedText;
-	                            break;
-	                        }
+	                        returnValue = convertValueToType(translatedText, type);
                         }
                     } else {
                         // extract this value
@@ -325,98 +361,7 @@ JsonFile.prototype.parseObj = function(json, root, schema, ref, name, localizabl
             break;
 
         case "array":
-            if (!ilib.isArray(json)) {
-               logger.warn(this.pathName + '/' + ref + " is a " +
-                   typeof(json) + " but should be an array according to the schema... skipping.");
-                return null;
-            }
-            // Convert all items to Strings so we can process them properly
-            var sourceArray = json.map(function(item) {
-                return String(item);
-            });
-
-            if (localizable) {
-                var key = JsonFile.unescapeRef(ref).substring(2);  // strip off the #/ part
-                if (translations) {
-                    // localize it
-                    var tester = this.API.newResource({
-                        resType: "array",
-                        project: this.project.getProjectId(),
-                        sourceLocale: this.project.getSourceLocale(),
-                        reskey: key,
-                        datatype: this.type.datatype
-                    });
-                    var hashkey = tester.hashKeyForTranslation(locale);
-                    var translated = translations.getClean(hashkey);
-                    var translatedArray;
-                    if (locale === this.project.pseudoLocale && this.project.settings.nopseudo) {
-                        translatedArray = this.sparseValue(sourceArray);
-                    } else if (!translated && this.type && this.type.pseudos[locale]) {
-                        var source, sourceLocale = this.type.pseudos[locale].getPseudoSourceLocale();
-                        if (sourceLocale !== this.project.sourceLocale) {
-                            // translation is derived from a different locale's translation instead of from the source string
-                            var sourceRes = translations.getClean(
-                                tester.cleanHashKey(),
-                                this.type.datatype);
-                            source = sourceRes ? sourceRes.getTargetArray() : sourceArray;
-                        } else {
-                            source = sourceArray;
-                        }
-                        translatedArray = source.map(function(item) {
-                            return this.type.pseudos[locale].getString(item);
-                        }.bind(this));
-                    } else {
-                        if (translated) {
-                            translatedArray = translated.getTargetArray();
-                        } else {
-                            if (this.type) {
-                                logger.trace("New string found: " + text);
-                                this.type.newres.add(this.API.newResource({
-                                    resType: "array",
-                                    project: this.project.getProjectId(),
-                                    key: key,
-                                    sourceLocale: this.project.sourceLocale,
-                                    sourceArray: sourceArray,
-                                    targetLocale: locale,
-                                    targetArray: sourceArray,
-                                    pathName: this.pathName,
-                                    state: "new",
-                                    datatype: this.type.datatype,
-                                    index: this.resourceIndex++
-                                }));
-                                if (this.type && this.type.missingPseudo && !this.project.settings.nopseudo) {
-                                    translatedArray = sourceArray.map(function(item) {
-                                        return this.type.missingPseudo.getString(item);
-                                    }.bind(this));
-                                    translatedArray = this.sparseValue(translatedArray);
-                                } else {
-                                    translatedArray = this.sparseValue(sourceArray);
-                                }
-                            } else {
-                                translatedArray = this.sparseValue(sourceArray);
-                            }
-                        }
-                    }
-                    returnValue = translatedArray;
-                } else {
-                    // extract this value
-                    this.set.add(this.API.newResource({
-                        resType: "array",
-                        project: this.project.getProjectId(),
-                        key: JsonFile.unescapeRef(ref).substring(2),
-                        sourceLocale: this.project.sourceLocale,
-                        sourceArray: sourceArray,
-                        pathName: this.pathName,
-                        state: "new",
-                        comment: this.comment,
-                        datatype: this.type.datatype,
-                        index: this.resourceIndex++
-                    }));
-                    returnValue = this.sparseValue(sourceArray);
-                }
-            } else {
-                returnValue = this.sparseValue(sourceArray);
-            }
+            returnValue = this.parseObjArray(json, root, schema, ref, name, localizable, translations, locale);
             break;
 
         case "object":
@@ -535,6 +480,8 @@ JsonFile.prototype.parseObj = function(json, root, schema, ref, name, localizabl
                             localizable,
                             translations,
                             locale);
+                    } else {
+                        returnValue[prop] = this.sparseValue(json[prop]);
                     }
                 }.bind(this));
             }
@@ -544,6 +491,136 @@ JsonFile.prototype.parseObj = function(json, root, schema, ref, name, localizabl
 
     return isNotEmpty(returnValue) ? returnValue : undefined;
 };
+
+JsonFile.prototype.parseObjArray = function(json, root, schema, ref, name, localizable, translations, locale) {
+    if (!ilib.isArray(json)) {
+        logger.warn(this.pathName + '/' + ref + " is a " +
+                typeof(json) + " but should be an array according to the schema... skipping.");
+        return null;
+    }
+
+    var arrayType = getArrayTypeFromSchema(schema);
+
+    if (arrayType === null) {
+        return this.sparseValue(json);
+    }
+
+    if (arrayType === 'object') {
+        // Continue parsing and treat array as a set of regular elements.
+        var returnValue = [];
+        for (var i = 0; i < json.length; i++) {
+            returnValue.push(
+                this.parseObj(
+                        json[i],
+                        root,
+                        schema.items,
+                        ref + '/' + JsonFile.escapeRef("item_" + i),
+                        "item_" + i,
+                        localizable,
+                        translations,
+                        locale
+                )
+            )
+        }
+
+        return returnValue;
+    }
+
+    // Convert all items to Strings so we can process them properly
+    var sourceArray = json.map(function(item) {
+        return String(item);
+    });
+
+    if (!localizable) {
+        return convertArrayElementsToType(this.sparseValue(sourceArray), arrayType);
+    }
+
+    if (!translations) {
+        // extract this value
+        this.set.add(this.API.newResource({
+            resType: "array",
+            project: this.project.getProjectId(),
+            key: JsonFile.unescapeRef(ref).substring(2),
+            sourceLocale: this.project.sourceLocale,
+            sourceArray: sourceArray,
+            pathName: this.pathName,
+            state: "new",
+            comment: this.comment,
+            datatype: this.type.datatype,
+            index: this.resourceIndex++
+        }));
+        return convertArrayElementsToType(this.sparseValue(sourceArray), arrayType);
+    }
+
+    if (locale === this.project.pseudoLocale && this.project.settings.nopseudo) {
+        return convertArrayElementsToType(this.sparseValue(sourceArray), arrayType);
+    }
+
+    var key = JsonFile.unescapeRef(ref).substring(2);  // strip off the #/ part
+    var tester = this.API.newResource({
+        resType: "array",
+        project: this.project.getProjectId(),
+        sourceLocale: this.project.getSourceLocale(),
+        reskey: key,
+        datatype: this.type.datatype
+    });
+    var hashkey = tester.hashKeyForTranslation(locale);
+    var translated = translations.getClean(hashkey);
+    var translatedArray;
+
+    if (!translated && this.type && this.type.pseudos[locale]) {
+        var source, sourceLocale = this.type.pseudos[locale].getPseudoSourceLocale();
+        if (sourceLocale !== this.project.sourceLocale) {
+            // translation is derived from a different locale's translation instead of from the source string
+            var sourceRes = translations.getClean(
+                    tester.cleanHashKey(),
+                    this.type.datatype);
+            source = sourceRes ? sourceRes.getTargetArray() : sourceArray;
+        } else {
+            source = sourceArray;
+        }
+        translatedArray = source.map(function(item) {
+            return this.type.pseudos[locale].getString(item);
+        }.bind(this));
+
+        return convertArrayElementsToType(translatedArray, arrayType);
+    }
+
+    if (translated) {
+        return convertArrayElementsToType(translated.getTargetArray(), arrayType);
+    }
+
+    if (!this.type) {
+        return convertArrayElementsToType(this.sparseValue(sourceArray), arrayType);
+    }
+
+    logger.trace("New strings found: " + sourceArray.toString());
+
+    this.type.newres.add(this.API.newResource({
+        resType: "array",
+        project: this.project.getProjectId(),
+        key: key,
+        sourceLocale: this.project.sourceLocale,
+        sourceArray: sourceArray,
+        targetLocale: locale,
+        targetArray: sourceArray,
+        pathName: this.pathName,
+        state: "new",
+        datatype: this.type.datatype,
+        index: this.resourceIndex++
+    }));
+
+    if (this.type.missingPseudo && !this.project.settings.nopseudo) {
+        translatedArray = sourceArray.map(function(item) {
+            return this.type.missingPseudo.getString(item);
+        }.bind(this));
+        translatedArray = this.sparseValue(translatedArray);
+    } else {
+        translatedArray = this.sparseValue(sourceArray);
+    }
+
+    return convertArrayElementsToType(translatedArray, arrayType);
+}
 
 /**
  * Parse the data string looking for the localizable strings and add them to the

--- a/JsonFile.js
+++ b/JsonFile.js
@@ -130,7 +130,7 @@ function isPrimitive(type) {
 }
 
 /**
- * Gets type of array of provided schema.
+ * Gets type of array based on provided schema.
  *
  * TODO: Add support for "anyOf" and "oneOf" type definitions.
  */

--- a/README.md
+++ b/README.md
@@ -302,6 +302,14 @@ file for more details.
 
 ## Release Notes
 
+### v1.1.0
+
+- extended array support:
+    1. corrected handling of primitive types. Values are casted to their initial type upon translation
+    2. added support for array of objects
+- fixed a bug of a copy method that results in json parts, that are not defined in the schema,
+to be removed from localized files
+
 ### v1.0.1
 
 - fixed a bug where plural strings resources were not extracted to the new

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
     "name": "ilib-loctool-json",
-    "version": "1.0.1",
+    "version": "1.1.0",
     "main": "./JsonFileType.js",
     "description": "A loctool plugin that knows how to localize json files",
     "license": "Apache-2.0",

--- a/test/testJsonFile.js
+++ b/test/testJsonFile.js
@@ -92,7 +92,12 @@ var p = new CustomProject({
                 "method": "copy",
                 "template": "resources/[locale]/refs.json"
             },
-            "**/str.json": {}
+            "**/str.json": {},
+            "**/arrays.json": {
+                "schema": "http://github.com/ilib-js/arrays.json",
+                "method": "copy",
+                "template": "resources/[localeDir]/arrays.json"
+            }
         }
     }
 });
@@ -512,6 +517,162 @@ module.exports.jsonfile = {
         test.equal(arrayStrings[0], "string 1");
         test.equal(arrayStrings[1], "string 2");
         test.equal(arrayStrings[2], "string 3");
+
+        test.done();
+    },
+
+    testJsonFileParseArrayOfStrings: function(test) {
+        test.expect(11);
+
+        // when it's named arrays.json, it should apply the arrays schema
+        var jf = new JsonFile({
+            project: p,
+            pathName: "i18n/arrays.json",
+            type: t
+        });
+        test.ok(jf);
+
+        jf.parse('{\n' +
+                '  "strings": [\n' +
+                '    "string 1",\n' +
+                '    "string 2",\n' +
+                '    "string 3"\n' +
+                '  ]\n' +
+                '}\n');
+
+        var set = jf.getTranslationSet();
+        test.ok(set);
+        test.equal(set.size(), 1);
+
+        var resources = set.getAll();
+        test.equal(resources.length, 1);
+        test.equal(resources[0].getType(), 'array');
+        test.equal(resources[0].getKey(), 'strings');
+
+        var arrayStrings = resources[0].getSourceArray();
+        test.ok(arrayStrings);
+        test.equal(arrayStrings.length, 3);
+        test.equal(arrayStrings[0], "string 1");
+        test.equal(arrayStrings[1], "string 2");
+        test.equal(arrayStrings[2], "string 3");
+
+        test.done();
+    },
+
+    testJsonFileParseArrayOfNumbers: function(test) {
+        test.expect(12);
+
+        var jf = new JsonFile({
+            project: p,
+            pathName: "i18n/arrays.json",
+            type: t
+        });
+        test.ok(jf);
+
+        jf.parse('{\n' +
+                '  "numbers": [\n' +
+                '    15,\n' +
+                '    -3,\n' +
+                '    1.18,\n' +
+                '    0\n' +
+                '  ]\n' +
+                '}\n');
+
+        var set = jf.getTranslationSet();
+        test.ok(set);
+        test.equal(set.size(), 1);
+
+        var resources = set.getAll();
+        test.equal(resources.length, 1);
+        test.equal(resources[0].getType(), 'array');
+        test.equal(resources[0].getKey(), 'numbers');
+
+        var arrayNumbers = resources[0].getSourceArray();
+        test.ok(arrayNumbers);
+        test.equal(arrayNumbers.length, 4);
+        test.equal(arrayNumbers[0], "15");
+        test.equal(arrayNumbers[1], "-3");
+        test.equal(arrayNumbers[2], "1.18");
+        test.equal(arrayNumbers[3], "0");
+
+        test.done();
+    },
+
+    testJsonFileParseArrayOfBooleans: function(test) {
+        test.expect(10);
+
+        var jf = new JsonFile({
+            project: p,
+            pathName: "i18n/arrays.json",
+            type: t
+        });
+        test.ok(jf);
+
+        jf.parse('{\n' +
+                '  "booleans": [\n' +
+                '    true,\n' +
+                '    false\n' +
+                '  ]\n' +
+                '}\n');
+
+        var set = jf.getTranslationSet();
+        test.ok(set);
+        test.equal(set.size(), 1);
+
+        var resources = set.getAll();
+        test.equal(resources.length, 1);
+        test.equal(resources[0].getType(), 'array');
+        test.equal(resources[0].getKey(), 'booleans');
+
+        var arrayBooleans = resources[0].getSourceArray();
+        test.ok(arrayBooleans);
+        test.equal(arrayBooleans.length, 2);
+        test.equal(arrayBooleans[0], "true");
+        test.equal(arrayBooleans[1], "false");
+
+        test.done();
+    },
+
+    testJsonFileParseArrayOfObjects: function(test) {
+        test.expect(13);
+
+        var jf = new JsonFile({
+            project: p,
+            pathName: "i18n/arrays.json",
+            type: t
+        });
+        test.ok(jf);
+
+        jf.parse('{\n' +
+                '  "objects": [\n' +
+                '    {\n' +
+                '      "name": "First Object",\n' +
+                '      "randomProp": "Non-translatable"\n' +
+                '    },\n' +
+                '    {\n' +
+                '      "name": "Second Object",\n' +
+                '      "description": "String property"\n' +
+                '    }\n' +
+                '  ]\n' +
+                '}\n');
+
+        var set = jf.getTranslationSet();
+        test.ok(set);
+        test.equal(set.size(), 3);
+
+        var resources = set.getAll();
+        test.equal(resources.length, 3);
+        test.equal(resources[0].getType(), 'string');
+        test.equal(resources[0].getKey(), 'objects/item_0/name');
+        test.equal(resources[0].getSource(), 'First Object');
+
+        test.equal(resources[1].getType(), 'string');
+        test.equal(resources[1].getKey(), 'objects/item_1/name');
+        test.equal(resources[1].getSource(), 'Second Object');
+
+        test.equal(resources[2].getType(), 'string');
+        test.equal(resources[2].getKey(), 'objects/item_1/description');
+        test.equal(resources[2].getSource(), 'String property');
 
         test.done();
     },
@@ -995,6 +1156,10 @@ module.exports.jsonfile = {
            '            "string 2",\n' +
            '            "string 3"\n' +
            '        ]\n' +
+           '    },\n' +
+           '    "others": {\n' +
+           '        "first": "abc",\n' +
+           '        "second": "bcd"\n' +
            '    }\n' +
            '}\n');
 
@@ -1072,6 +1237,10 @@ module.exports.jsonfile = {
            '            "chaîne 2",\n' +
            '            "chaîne 3"\n' +
            '        ]\n' +
+           '    },\n' +
+           '    "others": {\n' +
+           '        "first": "abc",\n' +
+           '        "second": "bcd"\n' +
            '    }\n' +
            '}\n';
 
@@ -1195,6 +1364,239 @@ module.exports.jsonfile = {
 
         diff(actual, expected);
         test.equal(actual, expected);
+        test.done();
+    },
+
+    testJsonFileLocalizeArrayOfStrings: function(test) {
+        test.expect(2);
+
+        var jf = new JsonFile({
+            project: p,
+            pathName: "i18n/arrays.json",
+            type: t
+        });
+        test.ok(jf);
+
+        jf.parse('{\n' +
+                '  "strings": [\n' +
+                '    "string 1",\n' +
+                '    "string 2",\n' +
+                '    "string 3"\n' +
+                '  ]\n' +
+                '}\n');
+
+        var translations = new TranslationSet('en-US');
+        translations.add(new ResourceArray({
+            project: "foo",
+            key: "strings",
+            sourceArray: [
+                "string 1",
+                "string 2",
+                "string 3"
+            ],
+            sourceLocale: "en-US",
+            targetArray: [
+                "chaîne 1",
+                "chaîne 2",
+                "chaîne 3"
+            ],
+            targetLocale: "fr-FR",
+            datatype: "json"
+        }));
+
+        var actual = jf.localizeText(translations, "fr-FR");
+        var expected =
+                '{\n' +
+                '    "strings": [\n' +
+                '        "chaîne 1",\n' +
+                '        "chaîne 2",\n' +
+                '        "chaîne 3"\n' +
+                '    ]\n' +
+                '}\n';
+
+        diff(actual, expected);
+        test.equal(actual, expected);
+
+        test.done();
+    },
+
+    testJsonFileLocalizeArrayOfNumbers: function(test) {
+        test.expect(2);
+
+        var jf = new JsonFile({
+            project: p,
+            pathName: "i18n/arrays.json",
+            type: t
+        });
+        test.ok(jf);
+
+        jf.parse('{\n' +
+                '  "numbers": [\n' +
+                '    15,\n' +
+                '    -3,\n' +
+                '    1.18,\n' +
+                '    0\n' +
+                '  ]\n' +
+                '}\n');
+
+        var translations = new TranslationSet('en-US');
+        translations.add(new ResourceArray({
+            project: "foo",
+            key: "numbers",
+            sourceArray: [
+                "15",
+                "-3",
+                "1.18",
+                "0"
+            ],
+            sourceLocale: "en-US",
+            targetArray: [
+                "29",
+                "12",
+                "-17.3",
+                "0"
+            ],
+            targetLocale: "fr-FR",
+            datatype: "json"
+        }));
+
+        var actual = jf.localizeText(translations, "fr-FR");
+        var expected =
+                '{\n' +
+                '    "numbers": [\n' +
+                '        29,\n' +
+                '        12,\n' +
+                '        -17.3,\n' +
+                '        0\n' +
+                '    ]\n' +
+                '}\n';
+
+        diff(actual, expected);
+        test.equal(actual, expected);
+
+        test.done();
+    },
+
+    testJsonFileLocalizeArrayOfBooleans: function(test) {
+        test.expect(2);
+
+        var jf = new JsonFile({
+            project: p,
+            pathName: "i18n/arrays.json",
+            type: t
+        });
+        test.ok(jf);
+
+        jf.parse('{\n' +
+                '  "booleans": [\n' +
+                '    true,\n' +
+                '    false\n' +
+                '  ]\n' +
+                '}\n');
+
+        var translations = new TranslationSet('en-US');
+        translations.add(new ResourceArray({
+            project: "foo",
+            key: "booleans",
+            sourceArray: [
+                "true",
+                "false"
+            ],
+            sourceLocale: "en-US",
+            targetArray: [
+                "false",
+                "true"
+            ],
+            targetLocale: "fr-FR",
+            datatype: "json"
+        }));
+
+        var actual = jf.localizeText(translations, "fr-FR");
+        var expected =
+                '{\n' +
+                '    "booleans": [\n' +
+                '        false,\n' +
+                '        true\n' +
+                '    ]\n' +
+                '}\n';
+
+        diff(actual, expected);
+        test.equal(actual, expected);
+
+        test.done();
+    },
+
+    testJsonFileLocalizeArrayOfObjects: function(test) {
+        test.expect(2);
+
+        var jf = new JsonFile({
+            project: p,
+            pathName: "i18n/arrays.json",
+            type: t
+        });
+        test.ok(jf);
+
+        jf.parse('{\n' +
+                '  "objects": [\n' +
+                '    {\n' +
+                '      "name": "First Object",\n' +
+                '      "randomProp": "Non-translatable"\n' +
+                '    },\n' +
+                '    {\n' +
+                '      "name": "Second Object",\n' +
+                '      "description": "String property"\n' +
+                '    }\n' +
+                '  ]\n' +
+                '}\n');
+
+        var translations = new TranslationSet('en-US');
+        translations.add(new ResourceString({
+            project: "foo",
+            key: "objects/item_0/name",
+            source: "First Object",
+            sourceLocale: "en-US",
+            target: "Premier objet",
+            targetLocale: "fr-FR",
+            datatype: "json"
+        }));
+        translations.add(new ResourceString({
+            project: "foo",
+            key: "objects/item_1/name",
+            source: "Second Object",
+            sourceLocale: "en-US",
+            target: "Deuxième objet",
+            targetLocale: "fr-FR",
+            datatype: "json"
+        }));
+
+        translations.add(new ResourceString({
+            project: "foo",
+            key: "objects/item_1/description",
+            source: "String Property",
+            sourceLocale: "en-US",
+            target: "Propriété String",
+            targetLocale: "fr-FR",
+            datatype: "json"
+        }));
+
+        var actual = jf.localizeText(translations, "fr-FR");
+        var expected =
+                '{\n' +
+                '    "objects": [\n' +
+                '        {\n' +
+                '            "name": "Premier objet",\n' +
+                '            "randomProp": "Non-translatable"\n' +
+                '        },\n' +
+                '        {\n' +
+                '            "name": "Deuxième objet",\n' +
+                '            "description": "Propriété String"\n' +
+                '        }\n' +
+                '    ]\n' +
+                '}\n';
+
+        diff(actual, expected);
+        test.equal(actual, expected);
+
         test.done();
     },
 

--- a/test/testfiles/schemas/arrays-schema.json
+++ b/test/testfiles/schemas/arrays-schema.json
@@ -1,0 +1,50 @@
+{
+  "$schema": "http://json-schema.org/draft-07/schema",
+  "$id": "http://github.com/ilib-js/arrays.json",
+  "type": "object",
+  "title": "The root schema",
+  "description": "The root schema comprises the entire JSON document.",
+  "properties": {
+    "strings": {
+      "type": "array",
+      "title": "Array of strings schema",
+      "localizable": true,
+      "items": {
+        "type": "string"
+      }
+    },
+    "numbers": {
+      "type": "array",
+      "title": "Array of numbers schema",
+      "localizable": true,
+      "items": {
+        "type": "number"
+      }
+    },
+    "booleans": {
+      "type": "array",
+      "title": "Array of booleans schema",
+      "localizable": true,
+      "items": {
+        "type": "boolean"
+      }
+    },
+    "objects": {
+      "type": "array",
+      "title": "Array of objects schema",
+      "items": {
+        "type": "object",
+        "properties": {
+          "name": {
+            "type": "string",
+            "localizable": true
+          },
+          "description": {
+            "type": "string",
+            "localizable": true
+          }
+        }
+      }
+    }
+  }
+}


### PR DESCRIPTION
- Correctly handle primitive types in array: after localization process all elements are converted back to their primitive types
- Add support for array type "object"
- Fix a bug with a copy method: parts of json structure not mentioned in the schema were not copied over translated files