### PR TITLE
Fix initialization of pseudo locales

### DIFF
--- a/JsonFileType.js
+++ b/JsonFileType.js
@@ -43,7 +43,7 @@ var JsonFileType = function(project) {
     this.pseudos = {};
 
     // generate all the pseudo bundles we'll need
-    project.locales && project.locales.forEach(function(locale) {
+    project.settings && project.settings.locales && project.settings.locales.forEach(function(locale) {
         var pseudo = this.API.getPseudoBundle(locale, this, project);
         if (pseudo) {
             this.pseudos[locale] = pseudo;

--- a/README.md
+++ b/README.md
@@ -302,6 +302,11 @@ file for more details.
 
 ## Release Notes
 
+### v1.2.2
+
+- Fix a bug where the pseudo locales were not initialized properly. This fix gets
+  the right set of locales from the project settings to see if any of them are pseudo locales.
+
 ### v1.2.1
 
 - Fixed bug where it was not generating pseudo localized text properly for missing

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
     "name": "ilib-loctool-json",
-    "version": "1.2.1",
+    "version": "1.2.2",
     "main": "./JsonFileType.js",
     "description": "A loctool plugin that knows how to localize json files",
     "license": "Apache-2.0",


### PR DESCRIPTION
- Fix a bug where the pseudo locales were not initialized properly. This fix gets the right set of locales from the project settings to see if any of them are pseudo locales.