### PR TITLE
Support file names within the current dir

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -26,8 +26,6 @@ workflows:
   test-all-node-versions:
     jobs:
       - test:
-          docker_image: circleci/node:8-browsers
-      - test:
           docker_image: circleci/node:10-browsers
       - test:
           docker_image: circleci/node:12-browsers
@@ -35,4 +33,6 @@ workflows:
           docker_image: circleci/node:13-browsers
       - test:
           docker_image: circleci/node:14-browsers
+      - test:
+          docker_image: circleci/node:16-browsers
       - test

--- a/JsonFile.js
+++ b/JsonFile.js
@@ -37,7 +37,7 @@ var logger = log4js.getLogger("loctool.plugin.JsonFile");
  */
 var JsonFile = function(options) {
     this.project = options.project;
-    this.pathName = options.pathName || "";
+    this.pathName = path.normalize(options.pathName || "");
     this.type = options.type;
 
     this.API = this.project.getAPI();

--- a/README.md
+++ b/README.md
@@ -302,6 +302,11 @@ file for more details.
 
 ## Release Notes
 
+### v1.2.4
+
+- normalize the path before matching against the mappings so that the matching
+  works better
+
 ### v1.2.3
 - fix issue of the parser that resulted in skipping objects with
   single boolean field which equals `false`

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
     "name": "ilib-loctool-json",
-    "version": "1.2.3",
+    "version": "1.2.4",
     "main": "./JsonFileType.js",
     "description": "A loctool plugin that knows how to localize json files",
     "license": "Apache-2.0",

--- a/test/testJsonFileType.js
+++ b/test/testJsonFileType.js
@@ -396,6 +396,21 @@ module.exports.jsonfiletype = {
         test.done();
     },
 
+     testJsonFileTypeGetMapping3: function(test) {
+        test.expect(2);
+
+        var jft = new JsonFileType(p);
+        test.ok(jft);
+
+        test.deepEqual(jft.getMapping("./messages.json"), {
+            "schema": "http://www.lge.com/json/messages",
+            "method": "copy",
+            "template": "resources/[localeDir]/messages.json"
+        });
+
+        test.done();
+    },
+
      testJsonFileTypeGetMappingNoMatch: function(test) {
         test.expect(2);
 
@@ -447,6 +462,17 @@ module.exports.jsonfiletype = {
         test.ok(jft);
 
         test.ok(jft.handles("x/y/z/messages.json"));
+
+        test.done();
+    },
+
+    testJsonFileTypeHandlesTrueWithDorDir: function(test) {
+        test.expect(2);
+
+        var jft = new JsonFileType(p);
+        test.ok(jft);
+
+        test.ok(jft.handles("./messages.json"));
 
         test.done();
     },

--- a/test/testJsonFileType.js
+++ b/test/testJsonFileType.js
@@ -466,7 +466,7 @@ module.exports.jsonfiletype = {
         test.done();
     },
 
-    testJsonFileTypeHandlesTrueWithDorDir: function(test) {
+    testJsonFileTypeHandlesTrueWithDotDir: function(test) {
         test.expect(2);
 
         var jft = new JsonFileType(p);


### PR DESCRIPTION
- the "." for the current dir confused the minimatch library, so to get around that, we normalize the path first before trying to match