### PR TITLE
Changes to be able to use this plugin as a resource file format

### DIFF
--- a/JsonFile.js
+++ b/JsonFile.js
@@ -676,8 +676,18 @@ JsonFile.prototype.getTranslationSet = function() {
     return this.set;
 }
 
-//we don't write Json source files
-JsonFile.prototype.write = function() {};
+JsonFile.prototype.write = function() {
+    if (!this.json && this.isDirty()) {
+        var locale = this.locale.getSpec();
+        var pathName = this.getLocalizedPath(locale);
+        this.logger.debug("Writing file " + pathName);
+        var p = path.join(this.project.target, pathName);
+        var d = path.dirname(p);
+        this.API.utils.makeDirs(d);
+
+        fs.writeFileSync(p, this.localizeText(undefined, locale), "utf-8");
+    }
+};
 
 
 /**

--- a/JsonFile.js
+++ b/JsonFile.js
@@ -679,7 +679,7 @@ JsonFile.prototype.getTranslationSet = function() {
 JsonFile.prototype.write = function() {
     if (!this.json && this.isDirty()) {
         var locale = this.locale.getSpec();
-        var pathName = this.getLocalizedPath(locale);
+        var pathName = this.pathName || this.getLocalizedPath(locale);
         this.logger.debug("Writing file " + pathName);
         var p = path.join(this.project.target, pathName);
         var d = path.dirname(p);

--- a/JsonFileType.js
+++ b/JsonFileType.js
@@ -233,9 +233,11 @@ JsonFileType.prototype.getMapping = function(pathName) {
     var jsonSettings = this.project.settings.json;
     var mappings = (jsonSettings && jsonSettings.mappings) ? jsonSettings.mappings : defaultMappings;
     var patterns = Object.keys(mappings);
-    var normalized = pathName.endsWith(".jso") || pathName.endsWith(".jsn") ?
-        pathName.substring(0, pathName.length - 4) + ".json" :
-        pathName;
+    var normalized = path.normalize(
+        pathName.endsWith(".jso") || pathName.endsWith(".jsn") ?
+            pathName.substring(0, pathName.length - 4) + ".json" :
+            pathName
+    );
 
     var match = patterns.find(function(pattern) {
         return mm.isMatch(pathName, pattern) || mm.isMatch(normalized, pattern);
@@ -255,7 +257,7 @@ JsonFileType.prototype.getMapping = function(pathName) {
 JsonFileType.prototype.handles = function(pathName) {
     this.logger.debug("JsonFileType handles " + pathName + "?");
     var ret = false;
-    var normalized = pathName;
+    var normalized = path.normalize(pathName);
 
     if (pathName.length > 4 &&
         (pathName.substring(pathName.length - 4) === ".jso" || pathName.substring(pathName.length - 4) === ".jsn")) {

--- a/JsonFileType.js
+++ b/JsonFileType.js
@@ -336,10 +336,10 @@ JsonFileType.prototype.write = function() {
     }
 };
 
-JsonFileType.prototype.newFile = function(path, options) {
+JsonFileType.prototype.newFile = function(pathName, options) {
     return new JsonFile({
         project: this.project,
-        pathName: path,
+        pathName: pathName,
         type: this,
         locale: options.locale
     });
@@ -351,16 +351,17 @@ JsonFileType.prototype.newFile = function(path, options) {
  *
  * @param {String} locale the name of the locale in which the resource
  * file will reside
+ * @param {String} pathName path to the resource file, if known, or undefined otherwise
  * @return {JavaScriptResourceFile} the Android resource file that serves the
  * given project, context, and locale.
  */
-JsonFileType.prototype.getResourceFile = function(locale) {
+JsonFileType.prototype.getResourceFile = function(locale, pathName) {
     var key = locale || this.project.sourceLocale;
 
     var resfile = this.resourceFiles && this.resourceFiles[key];
 
     if (!resfile) {
-        resfile = this.resourceFiles[key] = this.newFile(undefined, {
+        resfile = this.resourceFiles[key] = this.newFile(pathName, {
             project: this.project,
             locale: key
         });

--- a/JsonFileType.js
+++ b/JsonFileType.js
@@ -178,7 +178,7 @@ JsonFileType.prototype.getDefaultSchema = function() {
  * that schema is not defined
  */
 JsonFileType.prototype.getSchema = function(uri) {
-    return this.refs[uri] || this.getDefaultSchema();
+    return uri && this.refs[uri] || this.getDefaultSchema();
 };
 
 /**
@@ -197,18 +197,7 @@ JsonFileType.prototype.loadSchemas = function(pathName) {
         }
     } else {
         // default schema for all json files with key/value pairs
-        this.schemas = {
-            "default": {
-                "$schema": "http://json-schema.org/draft-07/schema",
-                "$id": "strings-schema",
-                "type": "object",
-                "description": "A collection of properties with localizable values",
-                "additionalProperties": {
-                    "type": "string",
-                    "localizable": true
-                }
-            }
-        }
+        this.schemas = this.getDefaultSchema();
         this.refs[this.schemas["default"]["$id"]] = this.schemas["default"];
     }
 
@@ -236,7 +225,7 @@ var defaultMappings = {
  */
 JsonFileType.prototype.getMapping = function(pathName) {
     if (typeof(pathName) === "undefined") {
-        return undefined;
+        return defaultMappings["**/*.json"];
     }
     var jsonSettings = this.project.settings.json;
     var mappings = (jsonSettings && jsonSettings.mappings) ? jsonSettings.mappings : defaultMappings;

--- a/README.md
+++ b/README.md
@@ -287,6 +287,65 @@ For strings that have an `enum` keyword, each of the values in the `enum` will
 not be translated as well, as the code that reads this json file is explicitly
 expecting one of the given fixed values.
 
+## JSON File Generation
+
+When you create a new, empty JsonFile instance that is not backed
+by a json file on disk, this plugin can generate the json file
+text automatically. This allows this plugin to be used as a resource
+file type for other plugins.
+
+```javascript
+    // path does not have to exist
+    var jsonFile = jsonFileType.newFile(path, {locale: "fr-FR"});
+
+    // the string, plural and array resource added in this example
+    // already have translations in them to fr-FR
+    jsonFile.addResource(stringResource);
+    jsonFile.addResource(pluralResource);
+    jsonFile.addResource(arrayResource);
+
+    // first param is the translation set from the xliff files
+    // and can be undefined for generated json files because
+    // the resources already have the translations in them
+    var text = jsonFile.getLocalizedText(undefined, "fr-FR");
+```
+
+### Generation of Each Resource Type
+
+The generation of resources into json has a hard-coded schema for now.
+(This may change in the future.) The hard-coded format is one that
+works with ilib's ResBundle class so that the output json can be
+loaded as string resources.
+
+For strings, they are output as simple key/value pairs:
+
+```json
+{
+    "key": "value"
+}
+```
+
+For arrays, they are output as json arrays:
+
+```json
+{
+    "key": [
+        "value at index 0",
+        "value at index 1",
+        etc
+        "value at index N"
+    ]
+}
+```
+
+For plurals, they are output as ilib plural strings:
+
+```json
+{
+    "key": "one#'one' category string|few#'few' category string|#'other' category string"
+}
+```
+
 ## Not a Validator
 
 Please note that this plugin is *not* a json schema validator, though it
@@ -301,6 +360,14 @@ This plugin is license under Apache2. See the [LICENSE](./LICENSE)
 file for more details.
 
 ## Release Notes
+
+### v1.3.0
+
+- added the ability to use this plugin as the output resource file format for other
+  plugins
+    - added addResource() to the JsonFile
+    - changed write so that if there is no existing json, it will generate
+      a new json file using hard-coded output templates
 
 ### v1.2.5
 

--- a/README.md
+++ b/README.md
@@ -104,7 +104,7 @@ used within the json property:
   similar to the the `includes` and `excludes` section of a
   `project.json` file. The value of that mapping is an object that
   can contain the following properties:
-    - schema: schema to use with that matcher. The schema is 
+    - schema: schema to use with that matcher. The schema is
       specified using the `$id` of one of the schemas loaded in the
       `schemas` property above. The default schema is "strings-schema"
       which is given in the previous section.
@@ -124,7 +124,7 @@ used within the json property:
         - [dir] the original directory where the matched source file
           came from. This is given as a directory that is relative
           to the root of the project. eg. "foo/bar/strings.json" -> "foo/bar"
-        - [filename] the file name of the matching file. 
+        - [filename] the file name of the matching file.
           eg. "foo/bar/strings.json" -> "strings.json"
         - [basename] the basename of the matching file without any extension
           eg. "foo/bar/strings.json" -> "strings"
@@ -210,7 +210,7 @@ When the `localizable` keyword is given for arrays,
 every item in the array is localizable and must be of a primitive type
 (string, integer, number, or boolean). If any array entries are not of
 a primitive type, an exception will be thrown and the localization will
-be halted. 
+be halted.
 
 When the `localizable` keyword
 is given for an object type, that object encodes a plural string. The
@@ -296,7 +296,7 @@ file type for other plugins.
 
 ```javascript
     // path does not have to exist
-    var jsonFile = jsonFileType.newFile(path, {locale: "fr-FR"});
+    var jsonFile = jsonFileType.newFile(undefined, {locale: "fr-FR"});
 
     // the string, plural and array resource added in this example
     // already have translations in them to fr-FR
@@ -309,6 +309,14 @@ file type for other plugins.
     // the resources already have the translations in them
     var text = jsonFile.getLocalizedText(undefined, "fr-FR");
 ```
+
+### Generated File Name
+
+If the `newFile` method is called without a path name, as in the above example,
+the default mapping will apply, and the output file will follow the default
+mapping's template. If a path name is given, but does not match any mapping,
+it will also use the default mapping. Otherwise, it will use the matched mapping
+to find the output file name.
 
 ### Generation of Each Resource Type
 

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
     "name": "ilib-loctool-json",
-    "version": "1.2.5",
+    "version": "1.3.0",
     "main": "./JsonFileType.js",
     "description": "A loctool plugin that knows how to localize json files",
     "license": "Apache-2.0",
@@ -49,7 +49,7 @@
         "clean": "git clean -f -d test"
     },
     "engines": {
-        "node": ">=6.0"
+        "node": ">=10.0"
     },
     "dependencies": {
         "ilib": "^14.14.0",

--- a/package.json
+++ b/package.json
@@ -57,7 +57,7 @@
     },
     "devDependencies": {
         "assertextras": "^1.1.0",
-        "loctool": "^2.16.2",
+        "loctool": "^2.16.3",
         "nodeunit": "^0.11.3"
     }
 }

--- a/test/testJsonFile.js
+++ b/test/testJsonFile.js
@@ -2480,5 +2480,287 @@ module.exports.jsonfile = {
         test.equal(content, expected);
 
         test.done();
+    },
+
+    testJsonFileGetLocalizedTextGeneratedString: function(test) {
+        test.expect(2);
+
+        var base = path.dirname(module.id);
+
+        var jf = new JsonFile({
+            project: p,
+            pathName: "x/y/str.json",
+            type: t,
+            locale: "fr-FR"
+        });
+        test.ok(jf);
+
+        jf.addResource(new ResourceString({
+            project: "foo",
+            key: "string 1",
+            source: "this is string one",
+            sourceLocale: "en-US",
+            target: "C'est la chaîne numéro 1",
+            targetLocale: "fr-FR",
+            datatype: "json"
+        }));
+
+        var actual = jf.localizeText(undefined, "fr-FR");
+        
+        var expected =
+           '{\n' +
+           '    "string 1": "C\'est la chaîne numéro 1"\n' +
+           '}\n';
+
+        diff(actual, expected);
+        test.equal(actual, expected);
+
+        test.done();
+    },
+
+    testJsonFileGetLocalizedTextGeneratedPlural: function(test) {
+        test.expect(2);
+
+        var base = path.dirname(module.id);
+
+        var jf = new JsonFile({
+            project: p,
+            pathName: "x/y/str.json",
+            type: t,
+            locale: "fr-FR"
+        });
+        test.ok(jf);
+
+        jf.addResource(new ResourcePlural({
+            project: "foo",
+            key: "string 1",
+            sourceStrings: {
+                "one": "this is the one string",
+                "few": "this is the few string",
+                "other": "this is the other string"
+            },
+            sourceLocale: "en-US",
+            targetStrings: {
+                "one": "Ceci est la chaîne 'one'",
+                "few": "Ceci est la chaîne 'few'",
+                "other": "Ceci est la chaîne 'other'"
+            },
+            targetLocale: "fr-FR",
+            datatype: "json"
+        }));
+
+        var actual = jf.localizeText(undefined, "fr-FR");
+        
+        var expected =
+           '{\n' +
+           '    "string 1": "one#Ceci est la chaîne \'one\'|few#Ceci est la chaîne \'few\'|#Ceci est la chaîne \'other\'"\n' +
+           '}\n';
+
+        diff(actual, expected);
+        test.equal(actual, expected);
+
+        test.done();
+    },
+
+    testJsonFileGetLocalizedTextGeneratedArray: function(test) {
+        test.expect(2);
+
+        var base = path.dirname(module.id);
+
+        var jf = new JsonFile({
+            project: p,
+            pathName: "x/y/str.json",
+            type: t,
+            locale: "fr-FR"
+        });
+        test.ok(jf);
+
+        jf.addResource(new ResourceArray({
+            project: "foo",
+            key: "string 1",
+            sourceArray: [
+                "this is string one",
+                "this is string two",
+                "this is string three"
+            ],
+            sourceLocale: "en-US",
+            targetArray: [
+                "C'est la chaîne numéro 1",
+                "C'est la chaîne numéro 2",
+                "C'est la chaîne numéro 3"
+            ],
+            targetLocale: "fr-FR",
+            datatype: "json"
+        }));
+
+        var actual = jf.localizeText(undefined, "fr-FR");
+        
+        var expected =
+           '{\n' +
+           '    "string 1": [\n' +
+           '        "C\'est la chaîne numéro 1",\n' +
+           '        "C\'est la chaîne numéro 2",\n' +
+           '        "C\'est la chaîne numéro 3"\n' +
+           '    ]\n' +
+           '}\n';
+
+        diff(actual, expected);
+        test.equal(actual, expected);
+
+        test.done();
+    },
+
+    testJsonFileGetLocalizedTextGeneratedAll: function(test) {
+        test.expect(2);
+
+        var base = path.dirname(module.id);
+
+        var jf = new JsonFile({
+            project: p,
+            pathName: "x/y/str.json",
+            type: t,
+            locale: "fr-FR"
+        });
+        test.ok(jf);
+
+        jf.addResource(new ResourceString({
+            project: "foo",
+            key: "string 1",
+            source: "this is string one",
+            sourceLocale: "en-US",
+            target: "C'est la chaîne numéro 1",
+            targetLocale: "fr-FR",
+            datatype: "json"
+        }));
+        jf.addResource(new ResourcePlural({
+            project: "foo",
+            key: "string 2",
+            sourceStrings: {
+                "one": "this is the one string",
+                "few": "this is the few string",
+                "other": "this is the other string"
+            },
+            sourceLocale: "en-US",
+            targetStrings: {
+                "one": "Ceci est la chaîne 'one'",
+                "few": "Ceci est la chaîne 'few'",
+                "other": "Ceci est la chaîne 'other'"
+            },
+            targetLocale: "fr-FR",
+            datatype: "json"
+        }));
+        jf.addResource(new ResourceArray({
+            project: "foo",
+            key: "string 3",
+            sourceArray: [
+                "this is string one",
+                "this is string two",
+                "this is string three"
+            ],
+            sourceLocale: "en-US",
+            targetArray: [
+                "C'est la chaîne numéro 1",
+                "C'est la chaîne numéro 2",
+                "C'est la chaîne numéro 3"
+            ],
+            targetLocale: "fr-FR",
+            datatype: "json"
+        }));
+
+        var actual = jf.localizeText(undefined, "fr-FR");
+        
+        var expected =
+           '{\n' +
+           '    "string 1": "C\'est la chaîne numéro 1",\n' +
+           '    "string 2": "one#Ceci est la chaîne \'one\'|few#Ceci est la chaîne \'few\'|#Ceci est la chaîne \'other\'",\n' +
+           '    "string 3": [\n' +
+           '        "C\'est la chaîne numéro 1",\n' +
+           '        "C\'est la chaîne numéro 2",\n' +
+           '        "C\'est la chaîne numéro 3"\n' +
+           '    ]\n' +
+           '}\n';
+
+        diff(actual, expected);
+        test.equal(actual, expected);
+
+        test.done();
+    },
+
+    testJsonFileGetLocalizedTextGeneratedEscapeDoubleQuotes: function(test) {
+        test.expect(2);
+
+        var base = path.dirname(module.id);
+
+        var jf = new JsonFile({
+            project: p,
+            pathName: "x/y/str.json",
+            type: t,
+            locale: "fr-FR"
+        });
+        test.ok(jf);
+
+        jf.addResource(new ResourceString({
+            project: "foo",
+            key: "string 1",
+            source: "this is string one",
+            sourceLocale: "en-US",
+            target: "C'est la \"chaîne\" numéro 1",
+            targetLocale: "fr-FR",
+            datatype: "json"
+        }));
+        jf.addResource(new ResourcePlural({
+            project: "foo",
+            key: "string 2",
+            sourceStrings: {
+                "one": "this is the one string",
+                "few": "this is the few string",
+                "other": "this is the other string"
+            },
+            sourceLocale: "en-US",
+            targetStrings: {
+                "one": "Ceci est la chaîne \"one\"",
+                "few": "Ceci est la chaîne \"few\"",
+                "other": "Ceci est la chaîne \"other\""
+            },
+            targetLocale: "fr-FR",
+            datatype: "json"
+        }));
+        jf.addResource(new ResourceArray({
+            project: "foo",
+            key: "string 3",
+            sourceArray: [
+                "this is string one",
+                "this is string two",
+                "this is string three"
+            ],
+            sourceLocale: "en-US",
+            targetArray: [
+                "C'est la chaîne numéro \"1\"",
+                "C'est la chaîne numéro \"2\"",
+                "C'est la chaîne numéro \"3\""
+            ],
+            targetLocale: "fr-FR",
+            datatype: "json"
+        }));
+
+        var actual = jf.localizeText(undefined, "fr-FR");
+        
+        // need to escape the double quotes for json syntax
+        var expected =
+           '{\n' +
+           '    "string 1": "C\'est la \\\"chaîne\\\" numéro 1",\n' +
+           '    "string 2": "one#Ceci est la chaîne \\\"one\\\"|few#Ceci est la chaîne \\\"few\\\"|#Ceci est la chaîne \\\"other\\\"",\n' +
+           '    "string 3": [\n' +
+           '        "C\'est la chaîne numéro \\\"1\\\"",\n' +
+           '        "C\'est la chaîne numéro \\\"2\\\"",\n' +
+           '        "C\'est la chaîne numéro \\\"3\\\""\n' +
+           '    ]\n' +
+           '}\n';
+
+        diff(actual, expected);
+        test.equal(actual, expected);
+
+        test.done();
     }
+
 };

--- a/test/testJsonFile.js
+++ b/test/testJsonFile.js
@@ -2506,7 +2506,7 @@ module.exports.jsonfile = {
         }));
 
         var actual = jf.localizeText(undefined, "fr-FR");
-        
+
         var expected =
            '{\n' +
            '    "string 1": "C\'est la chaîne numéro 1"\n' +
@@ -2550,7 +2550,7 @@ module.exports.jsonfile = {
         }));
 
         var actual = jf.localizeText(undefined, "fr-FR");
-        
+
         var expected =
            '{\n' +
            '    "string 1": "one#Ceci est la chaîne \'one\'|few#Ceci est la chaîne \'few\'|#Ceci est la chaîne \'other\'"\n' +
@@ -2594,7 +2594,7 @@ module.exports.jsonfile = {
         }));
 
         var actual = jf.localizeText(undefined, "fr-FR");
-        
+
         var expected =
            '{\n' +
            '    "string 1": [\n' +
@@ -2668,7 +2668,7 @@ module.exports.jsonfile = {
         }));
 
         var actual = jf.localizeText(undefined, "fr-FR");
-        
+
         var expected =
            '{\n' +
            '    "string 1": "C\'est la chaîne numéro 1",\n' +
@@ -2744,7 +2744,7 @@ module.exports.jsonfile = {
         }));
 
         var actual = jf.localizeText(undefined, "fr-FR");
-        
+
         // need to escape the double quotes for json syntax
         var expected =
            '{\n' +


### PR DESCRIPTION
- implemented `JsonFile.write()`, `JsonFile.addResource()`, and `JsonFile.generateText()`
- implemented `JsonFileType.getResourceFile()`
- when localizing the file, if there is no json loaded but there are resources added, then we generate the text. Otherwise, it is localized with the translations the way it was before
- version bumped -> v1.3.0