### PR TITLE
Fix a bug with empty objects used as array elements

### DIFF
--- a/JsonFile.js
+++ b/JsonFile.js
@@ -212,7 +212,7 @@ var pluralCategories = {
 function isPlural(node) {
     if (!node) return false;
     var props = Object.keys(node);
-    return props.every(function(prop) {
+    return Object.keys(node).length && props.every(function(prop) {
         return pluralCategories[prop] && typeof(node[prop]) === "string";
     });
 }
@@ -597,18 +597,22 @@ JsonFile.prototype.parseObjArray = function(json, root, schema, ref, name, local
         // Continue parsing and treat array as a set of regular elements.
         var returnValue = [];
         for (var i = 0; i < json.length; i++) {
-            returnValue.push(
-                this.parseObj(
-                        json[i],
-                        root,
-                        schema.items,
-                        ref + '/' + JsonFile.escapeRef("item_" + i),
-                        "item_" + i,
-                        localizable,
-                        translations,
-                        locale
-                )
-            )
+            var element = this.parseObj(
+                json[i],
+                root,
+                schema.items,
+                ref + '/' + JsonFile.escapeRef("item_" + i),
+                "item_" + i,
+                localizable,
+                translations,
+                locale
+            );
+            if (!element) {
+                // Arrays are special -- put the original element back even if the
+                // subvalue contains nothing localizable
+                element = this.sparseValue(json[i]);
+            }
+            returnValue.push(element);
         }
 
         return returnValue;

--- a/README.md
+++ b/README.md
@@ -381,6 +381,12 @@ file for more details.
 
 ## Release Notes
 
+### v1.5.4
+
+- fixed a bug where array entries without any localizable values in
+  them were being coming out as `null` in the localized json files.
+- updated dependencies
+
 ### v1.5.3
 
 - update dependencies

--- a/package.json
+++ b/package.json
@@ -48,7 +48,7 @@
         "test:watch": "jest --watch",
         "debug": "node --inspect-brk node_modules/.bin/jest -i",
         "clean": "git clean -f -d test",
-        "postinstall": "conditional-install"
+        "prepare": "conditional-install"
     },
     "engines": {
         "node": ">=10.0"
@@ -63,14 +63,10 @@
     },
     "conditionalDependencies": {
         "process.versions.node < 14.0.0": {
-            "jest": "^26.0.0",
-            "jest-mock": "^26.0.0",
-            "expect": "^26.0.0"
+            "jest": "^26.0.0"
         },
         "process.versions.node >= 14.0.0": {
-            "jest": "^29.0.0",
-            "jest-mock": "^29.0.0",
-            "expect": "^29.0.0"
+            "jest": "^29.0.0"
         }
     }
 }

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
     "name": "ilib-loctool-json",
-    "version": "1.5.3",
+    "version": "1.5.4",
     "main": "./JsonFileType.js",
     "description": "A loctool plugin that knows how to localize json files",
     "license": "Apache-2.0",
@@ -47,17 +47,30 @@
         "test": "jest",
         "test:watch": "jest --watch",
         "debug": "node --inspect-brk node_modules/.bin/jest -i",
-        "clean": "git clean -f -d test"
+        "clean": "git clean -f -d test",
+        "postinstall": "conditional-install"
     },
     "engines": {
         "node": ">=10.0"
     },
     "dependencies": {
-        "ilib": "^14.18.0",
+        "ilib": "^14.19.0",
         "json5": "^2.2.3"
     },
     "devDependencies": {
-        "jest": "^26.6.3",
+        "conditional-install": "^1.0.1",
         "loctool": "^2.23.1"
+    },
+    "conditionalDependencies": {
+        "process.versions.node < 14.0.0": {
+            "jest": "^26.0.0",
+            "jest-mock": "^26.0.0",
+            "expect": "^26.0.0"
+        },
+        "process.versions.node >= 14.0.0": {
+            "jest": "^29.0.0",
+            "jest-mock": "^29.0.0",
+            "expect": "^29.0.0"
+        }
     }
 }

--- a/test/JsonFile.test.js
+++ b/test/JsonFile.test.js
@@ -1745,6 +1745,79 @@ describe("jsonfile", function() {
         expect(actual).toBe(expected);
     });
 
+    test("Localize an array of objects that includes an empty object", function() {
+        expect.assertions(2);
+
+        var jf = new JsonFile({
+            project: p,
+            pathName: "i18n/arrays.json",
+            type: t
+        });
+        expect(jf).toBeTruthy();
+
+        jf.parse('{\n' +
+                '  "objects": [\n' +
+                '    {},\n' +
+                '    {\n' +
+                '      "name": "First Object",\n' +
+                '      "randomProp": "Non-translatable"\n' +
+                '    },\n' +
+                '    {\n' +
+                '      "name": "Second Object",\n' +
+                '      "description": "String property"\n' +
+                '    }\n' +
+                '  ]\n' +
+                '}\n');
+
+        var translations = new TranslationSet('en-US');
+        translations.add(new ResourceString({
+            project: "foo",
+            key: "objects/item_1/name",
+            source: "First Object",
+            sourceLocale: "en-US",
+            target: "Premier objet",
+            targetLocale: "fr-FR",
+            datatype: "json"
+        }));
+        translations.add(new ResourceString({
+            project: "foo",
+            key: "objects/item_2/name",
+            source: "Second Object",
+            sourceLocale: "en-US",
+            target: "Deuxième objet",
+            targetLocale: "fr-FR",
+            datatype: "json"
+        }));
+        translations.add(new ResourceString({
+            project: "foo",
+            key: "objects/item_2/description",
+            source: "String Property",
+            sourceLocale: "en-US",
+            target: "Propriété String",
+            targetLocale: "fr-FR",
+            datatype: "json"
+        }));
+
+        var actual = jf.localizeText(translations, "fr-FR");
+        var expected =
+                '{\n' +
+                '    "objects": [\n' +
+                '        {},\n' +
+                '        {\n' +
+                '            "name": "Premier objet",\n' +
+                '            "randomProp": "Non-translatable"\n' +
+                '        },\n' +
+                '        {\n' +
+                '            "name": "Deuxième objet",\n' +
+                '            "description": "Propriété String"\n' +
+                '        }\n' +
+                '    ]\n' +
+                '}\n';
+
+        diff(actual, expected);
+        expect(actual).toBe(expected);
+    });
+
     test("JsonFileLocalizeTextUsePseudoForMissing", function() {
         expect.assertions(2);
 


### PR DESCRIPTION
- fixed a bug where array entries without any localizable values in
  them were being coming out as `null` in the localized json files.
- updated dependencies

Cannot be merged until the [conditionalInstall PR](https://github.com/iLib-js/conditionalInstall/pull/2) is merged.